### PR TITLE
feat(auth): add user sign-up and sign-in logic

### DIFF
--- a/backend/packages/libs/auth/package.json
+++ b/backend/packages/libs/auth/package.json
@@ -2,7 +2,6 @@
   "name": "@kedge/auth",
   "version": "0.0.1",
   "dependencies": {
-    "@kedge/common": "*",
     "@kedge/models": "*",
     "@kedge/persistent": "*",
     "@nestjs/common": "^10.0.0",
@@ -11,7 +10,9 @@
     "slonik": "^37.2.0",
     "zod": "^3.22.4",
     "@nestjs/jwt": "^11.0.0",
-    "@nestjs/passport": "^11.0.5"
+    "@nestjs/passport": "^11.0.5",
+    "passport-jwt": "^4.0.1",
+    "jsonwebtoken": "^9.0.2"
   },
   "type": "commonjs",
   "main": "./src/index.js",

--- a/backend/packages/libs/auth/src/lib/auth.interface.ts
+++ b/backend/packages/libs/auth/src/lib/auth.interface.ts
@@ -1,3 +1,14 @@
+import { User, UserRole } from '@kedge/models';
+
 export abstract class AuthService {
-  abstract signIn(message: string, signature: string): Promise<{ accessToken: string, userId?: string }>;
+  abstract createUser(
+    name: string,
+    password: string,
+    role: UserRole,
+  ): Promise<User>;
+
+  abstract signIn(
+    name: string,
+    password: string,
+  ): Promise<{ accessToken: string; userId: string }>;
 }

--- a/backend/packages/libs/auth/src/lib/auth.repository.ts
+++ b/backend/packages/libs/auth/src/lib/auth.repository.ts
@@ -2,6 +2,14 @@ import { Injectable, Logger } from "@nestjs/common";
 import { PersistentService } from '@kedge/persistent';
 import { sql } from 'slonik';
 import { UserSchema, User, UserRole } from '@kedge/models';
+import { z } from 'zod';
+
+const UserWithCredentialsSchema = UserSchema.extend({
+  password_hash: z.string(),
+  salt: z.string(),
+});
+
+type UserWithCredentials = z.infer<typeof UserWithCredentialsSchema>;
 
 @Injectable()
 export class AuthRepository {
@@ -12,20 +20,33 @@ export class AuthRepository {
   /**
    * create new user
    */
-  async createUser(data: { name: string, password: string, role: UserRole }): Promise<User> {
+  async createUser(data: {
+    name: string;
+    passwordHash: string;
+    salt: string;
+    role: UserRole;
+  }): Promise<User> {
     try {
       const result = await this.persistentService.pgPool.query(
         sql.type(UserSchema)`
           INSERT INTO kedge_gateway.users (
-// TODO: add more
+            name,
+            password_hash,
+            salt,
+            role,
+            created_at,
             updated_at
           )
           VALUES (
-// TODO: add more
+            ${data.name},
+            ${data.passwordHash},
+            ${data.salt},
+            ${data.role},
+            now(),
             now()
           )
-          RETURNING *
-        `
+          RETURNING id, name AS username, role, created_at, updated_at
+        `,
       );
 
       return result.rows[0];
@@ -33,6 +54,30 @@ export class AuthRepository {
       const errorMessage = error instanceof Error ? error.message : String(error);
       this.logger.error(`Error creating user: ${errorMessage}`);
       throw new Error('Failed to create user');
+    }
+  }
+
+  async findUserByName(name: string): Promise<UserWithCredentials | null> {
+    try {
+      const result = await this.persistentService.pgPool.query(
+        sql.type(UserWithCredentialsSchema)`
+          SELECT id,
+                 name AS username,
+                 password_hash,
+                 salt,
+                 role,
+                 created_at,
+                 updated_at
+          FROM kedge_gateway.users
+          WHERE name = ${name}
+        `,
+      );
+
+      return result.rows[0] ?? null;
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      this.logger.error(`Error finding user by name: ${errorMessage}`);
+      throw new Error('Failed to find user');
     }
   }
 }


### PR DESCRIPTION
## Summary
- support creating users with hashed passwords and roles
- enable password-based sign-in with JWT issuance
- declare JWT dependencies

## Testing
- `npx nx lint lib-auth`
- `npx nx build lib-auth`


------
https://chatgpt.com/codex/tasks/task_e_688e33a58e088324a983328076b67ad4