### PR TITLE
feat(auth): add user sign-up and sign-in logic

### DIFF
--- a/backend/packages/apps/api-server/src/app/app.module.ts
+++ b/backend/packages/apps/api-server/src/app/app.module.ts
@@ -1,11 +1,17 @@
 import { Module } from '@nestjs/common';
 import { APP_PIPE } from '@nestjs/core';
 import { ZodValidationPipe } from 'nestjs-zod';
+import { AuthModule } from '@kedge/auth';
+import { AuthController } from './auth.controller';
+import { IndexController } from './index.controller';
 
 @Module({
   imports: [
+    AuthModule,
   ],
   controllers: [
+    AuthController,
+    IndexController,
   ],
   providers: [
     {

--- a/backend/packages/apps/api-server/src/app/auth.controller.ts
+++ b/backend/packages/apps/api-server/src/app/auth.controller.ts
@@ -1,0 +1,35 @@
+import { Body, Controller, Post } from '@nestjs/common';
+import { createZodDto } from 'nestjs-zod';
+import { z } from 'zod';
+import { AuthService } from '@kedge/auth';
+import { User, UserRole, UserRoleSchema } from '@kedge/models';
+
+const SignUpSchema = z.object({
+  name: z.string(),
+  password: z.string(),
+  role: UserRoleSchema,
+});
+
+export class SignUpDto extends createZodDto(SignUpSchema) {}
+
+const SignInSchema = z.object({
+  name: z.string(),
+  password: z.string(),
+});
+
+export class SignInDto extends createZodDto(SignInSchema) {}
+
+@Controller('auth')
+export class AuthController {
+  constructor(private readonly authService: AuthService) {}
+
+  @Post('sign-up')
+  signUp(@Body() body: SignUpDto): Promise<User> {
+    return this.authService.createUser(body.name, body.password, body.role);
+  }
+
+  @Post('sign-in')
+  signIn(@Body() body: SignInDto) {
+    return this.authService.signIn(body.name, body.password);
+  }
+}

--- a/backend/packages/apps/api-server/src/app/index.controller.ts
+++ b/backend/packages/apps/api-server/src/app/index.controller.ts
@@ -1,0 +1,14 @@
+import { Controller, Get } from '@nestjs/common';
+
+@Controller()
+export class IndexController {
+  @Get()
+  index(): string {
+    return 'kedge API';
+  }
+
+  @Get('healthz')
+  health(): string {
+    return 'OK';
+  }
+}

--- a/backend/packages/apps/api-server/test/app.e2e.spec.ts
+++ b/backend/packages/apps/api-server/test/app.e2e.spec.ts
@@ -7,6 +7,7 @@ describe('IndexController (e2e)', () => {
   let app: INestApplication;
 
   beforeEach(async () => {
+    process.env.JWT_SECRET = 'test';
     const moduleFixture: TestingModule = await Test.createTestingModule({
       imports: [AppModule],
     }).compile();

--- a/backend/packages/libs/auth/package.json
+++ b/backend/packages/libs/auth/package.json
@@ -2,7 +2,6 @@
   "name": "@kedge/auth",
   "version": "0.0.1",
   "dependencies": {
-    "@kedge/common": "*",
     "@kedge/models": "*",
     "@kedge/persistent": "*",
     "@nestjs/common": "^10.0.0",
@@ -11,7 +10,9 @@
     "slonik": "^37.2.0",
     "zod": "^3.22.4",
     "@nestjs/jwt": "^11.0.0",
-    "@nestjs/passport": "^11.0.5"
+    "@nestjs/passport": "^11.0.5",
+    "passport-jwt": "^4.0.1",
+    "jsonwebtoken": "^9.0.2"
   },
   "type": "commonjs",
   "main": "./src/index.js",

--- a/backend/packages/libs/auth/src/lib/auth.interface.ts
+++ b/backend/packages/libs/auth/src/lib/auth.interface.ts
@@ -1,3 +1,14 @@
+import { User, UserRole } from '@kedge/models';
+
 export abstract class AuthService {
-  abstract signIn(message: string, signature: string): Promise<{ accessToken: string, userId?: string }>;
+  abstract createUser(
+    name: string,
+    password: string,
+    role: UserRole,
+  ): Promise<User>;
+
+  abstract signIn(
+    name: string,
+    password: string,
+  ): Promise<{ accessToken: string; userId: string }>;
 }

--- a/backend/packages/libs/auth/src/lib/auth.repository.ts
+++ b/backend/packages/libs/auth/src/lib/auth.repository.ts
@@ -1,7 +1,13 @@
 import { Injectable, Logger } from "@nestjs/common";
 import { PersistentService } from '@kedge/persistent';
 import { sql } from 'slonik';
-import { UserSchema, User, UserRole } from '@kedge/models';
+import {
+  UserSchema,
+  UserWithCredentialsSchema,
+  User,
+  UserWithCredentials,
+  UserRole,
+} from '@kedge/models';
 
 @Injectable()
 export class AuthRepository {
@@ -12,20 +18,33 @@ export class AuthRepository {
   /**
    * create new user
    */
-  async createUser(data: { name: string, password: string, role: UserRole }): Promise<User> {
+  async createUser(data: {
+    name: string;
+    passwordHash: string;
+    salt: string;
+    role: UserRole;
+  }): Promise<User> {
     try {
       const result = await this.persistentService.pgPool.query(
         sql.type(UserSchema)`
           INSERT INTO kedge_gateway.users (
-// TODO: add more
+            name,
+            password_hash,
+            salt,
+            role,
+            created_at,
             updated_at
           )
           VALUES (
-// TODO: add more
+            ${data.name},
+            ${data.passwordHash},
+            ${data.salt},
+            ${data.role},
+            now(),
             now()
           )
-          RETURNING *
-        `
+          RETURNING id, name, role, created_at, updated_at
+        `,
       );
 
       return result.rows[0];
@@ -33,6 +52,30 @@ export class AuthRepository {
       const errorMessage = error instanceof Error ? error.message : String(error);
       this.logger.error(`Error creating user: ${errorMessage}`);
       throw new Error('Failed to create user');
+    }
+  }
+
+  async findUserByName(name: string): Promise<UserWithCredentials | null> {
+    try {
+      const result = await this.persistentService.pgPool.query(
+        sql.type(UserWithCredentialsSchema)`
+          SELECT id,
+                 name,
+                 password_hash,
+                 salt,
+                 role,
+                 created_at,
+                 updated_at
+          FROM kedge_gateway.users
+          WHERE name = ${name}
+        `,
+      );
+
+      return result.rows[0] ?? null;
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      this.logger.error(`Error finding user by name: ${errorMessage}`);
+      throw new Error('Failed to find user');
     }
   }
 }

--- a/backend/packages/libs/models/package.json
+++ b/backend/packages/libs/models/package.json
@@ -2,9 +2,7 @@
   "name": "@kedge/models",
   "version": "0.0.1",
   "dependencies": {
-    "viem": "^1.18.2",
-    "zod": "^3.22.2",
-    "@kedge/models-workflow": "*"
+    "zod": "^3.22.2"
   },
   "type": "commonjs",
   "main": "./src/index.js",

--- a/backend/packages/libs/models/src/auth/auth.repository.schema.ts
+++ b/backend/packages/libs/models/src/auth/auth.repository.schema.ts
@@ -5,13 +5,20 @@ export type UserRole = z.infer<typeof UserRoleSchema>;
 
 export const UserSchema = z.object({
   id: z.string().uuid(),
-  username: z.string(),
+  name: z.string(),
   role: UserRoleSchema,
   created_at: z.string(),
-  updated_at: z.string()
+  updated_at: z.string(),
 });
 
 export type User = z.infer<typeof UserSchema>;
+
+export const UserWithCredentialsSchema = UserSchema.extend({
+  password_hash: z.string(),
+  salt: z.string(),
+});
+
+export type UserWithCredentials = z.infer<typeof UserWithCredentialsSchema>;
 
 /**
  * All auth related schemas
@@ -19,4 +26,5 @@ export type User = z.infer<typeof UserSchema>;
 export const AuthRepositorySchemas = {
   User: UserSchema,
   UserRole: UserRoleSchema,
+  UserWithCredentials: UserWithCredentialsSchema,
 };

--- a/backend/packages/libs/models/src/auth/index.ts
+++ b/backend/packages/libs/models/src/auth/index.ts
@@ -1,5 +1,9 @@
 import { JwtPayloadSchema } from './jwt-payload.schema';
-import { UserSchema, AuthRepositorySchemas } from './auth.repository.schema';
+import {
+  UserSchema,
+  UserWithCredentialsSchema,
+  AuthRepositorySchemas,
+} from './auth.repository.schema';
 
 export const AuthSchema = {
   jwt_payload: JwtPayloadSchema
@@ -8,9 +12,11 @@ export const AuthSchema = {
 export {
   UserSchema,
   User,
-    UserRoleSchema,
-    UserRole,
-  AuthRepositorySchemas
+  UserWithCredentialsSchema,
+  UserWithCredentials,
+  UserRoleSchema,
+  UserRole,
+  AuthRepositorySchemas,
 } from './auth.repository.schema';
 
 export { JwtPayloadSchema } from './jwt-payload.schema';


### PR DESCRIPTION
## Summary
- support creating users with hashed passwords and roles
- enable password-based sign-in with JWT issuance
- centralize auth models in @kedge/models and align user field names
- declare JWT dependencies
- expose auth API routes for sign-up and sign-in
- provide basic index and health endpoints

## Testing
- `npx nx lint models`
- `npx nx build models`
- `npx nx lint lib-auth`
- `npx nx build lib-auth`
- `npx nx lint api-server`
- `npx nx build api-server`
- `npx nx test api-server`


------
https://chatgpt.com/codex/tasks/task_e_688e33a58e088324a983328076b67ad4