### PR TITLE
Add admin role and restrict user creation

### DIFF
--- a/backend/packages/apps/api-server/src/app/auth.controller.ts
+++ b/backend/packages/apps/api-server/src/app/auth.controller.ts
@@ -1,7 +1,16 @@
-import { Body, Controller, Post } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  NotFoundException,
+  Post,
+  Req,
+  UseGuards,
+} from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
+import { Request } from 'express';
 import { createZodDto } from 'nestjs-zod';
 import { z } from 'zod';
-import { AuthService } from '@kedge/auth';
+import { AuthService, JwtAuthGuard, AdminGuard } from '@kedge/auth';
 import { User, UserRole, UserRoleSchema } from '@kedge/models';
 
 const SignUpSchema = z.object({
@@ -21,9 +30,13 @@ export class SignInDto extends createZodDto(SignInSchema) {}
 
 @Controller('auth')
 export class AuthController {
-  constructor(private readonly authService: AuthService) {}
+  constructor(
+    private readonly authService: AuthService,
+    private readonly jwtService: JwtService,
+  ) {}
 
   @Post('sign-up')
+  @UseGuards(JwtAuthGuard, AdminGuard)
   signUp(@Body() body: SignUpDto): Promise<User> {
     return this.authService.createUser(body.name, body.password, body.role);
   }
@@ -31,5 +44,23 @@ export class AuthController {
   @Post('sign-in')
   signIn(@Body() body: SignInDto) {
     return this.authService.signIn(body.name, body.password);
+  }
+
+  @Post('mock-admin-sign-in')
+  async mockAdminSignIn(@Req() req: Request) {
+    const ip = req.ip;
+    if (
+      ip !== '127.0.0.1' &&
+      ip !== '::1' &&
+      ip !== '::ffff:127.0.0.1'
+    ) {
+      throw new NotFoundException();
+    }
+
+    const payload = { sub: 'mock-admin', role: 'admin' as UserRole };
+    return {
+      accessToken: await this.jwtService.signAsync(payload),
+      userId: 'mock-admin',
+    };
   }
 }

--- a/backend/packages/apps/api-server/src/app/docx.controller.ts
+++ b/backend/packages/apps/api-server/src/app/docx.controller.ts
@@ -1,5 +1,6 @@
-import { Controller, Post, UploadedFile, UseInterceptors } from '@nestjs/common';
+import { Controller, Post, UploadedFile, UseInterceptors, UseGuards } from '@nestjs/common';
 import { FileInterceptor } from '@nestjs/platform-express';
+import { JwtAuthGuard, TeacherGuard } from '@kedge/auth';
 import { DocxService, GptService } from '@kedge/quiz-parser';
 
 interface MulterFile {
@@ -7,6 +8,7 @@ interface MulterFile {
   [key: string]: unknown;
 }
 
+@UseGuards(JwtAuthGuard, TeacherGuard)
 @Controller('docx')
 export class DocxController {
   constructor(

--- a/backend/packages/apps/api-server/src/app/gpt.controller.ts
+++ b/backend/packages/apps/api-server/src/app/gpt.controller.ts
@@ -1,6 +1,8 @@
-import { Controller, Post, Body } from '@nestjs/common';
+import { Controller, Post, Body, UseGuards } from '@nestjs/common';
+import { JwtAuthGuard, TeacherGuard } from '@kedge/auth';
 import { GptService, QuizItem } from '@kedge/quiz-parser';
 
+@UseGuards(JwtAuthGuard, TeacherGuard)
 @Controller('gpt')
 export class GptController {
   constructor(private readonly gptService: GptService) {}

--- a/backend/packages/libs/auth/src/index.ts
+++ b/backend/packages/libs/auth/src/index.ts
@@ -4,3 +4,5 @@ export * from './lib/auth.interface';
 export * from './lib/auth.repository';
 export * from './jwt/jwt-auth.guard';
 export * from './jwt/jwt.strategy';
+export * from './jwt/teacher.guard';
+export * from './jwt/admin.guard';

--- a/backend/packages/libs/auth/src/jwt/admin.guard.ts
+++ b/backend/packages/libs/auth/src/jwt/admin.guard.ts
@@ -1,0 +1,14 @@
+import { CanActivate, ExecutionContext, ForbiddenException, Injectable } from '@nestjs/common';
+import { UserRole } from '@kedge/models';
+
+@Injectable()
+export class AdminGuard implements CanActivate {
+  canActivate(context: ExecutionContext): boolean {
+    const request = context.switchToHttp().getRequest();
+    const user = request.user as { role?: UserRole } | undefined;
+    if (user?.role !== 'admin') {
+      throw new ForbiddenException('Only admins can access this resource');
+    }
+    return true;
+  }
+}

--- a/backend/packages/libs/auth/src/jwt/teacher.guard.ts
+++ b/backend/packages/libs/auth/src/jwt/teacher.guard.ts
@@ -1,0 +1,14 @@
+import { CanActivate, ExecutionContext, ForbiddenException, Injectable } from '@nestjs/common';
+import { UserRole } from '@kedge/models';
+
+@Injectable()
+export class TeacherGuard implements CanActivate {
+  canActivate(context: ExecutionContext): boolean {
+    const request = context.switchToHttp().getRequest();
+    const user = request.user as { role?: UserRole } | undefined;
+    if (user?.role !== 'teacher') {
+      throw new ForbiddenException('Only teachers can access this resource');
+    }
+    return true;
+  }
+}

--- a/backend/packages/libs/auth/src/lib/auth.module.ts
+++ b/backend/packages/libs/auth/src/lib/auth.module.ts
@@ -28,6 +28,7 @@ import { AuthRepository } from './auth.repository';
   exports: [
     AuthServiceProvider,
     JwtAuthGuard,
+    JwtModule,
   ]
 })
 export class AuthModule {}

--- a/backend/packages/libs/models/src/auth/auth.repository.schema.ts
+++ b/backend/packages/libs/models/src/auth/auth.repository.schema.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 
-export const UserRoleSchema = z.enum(['student', 'teacher'])
+export const UserRoleSchema = z.enum(['student', 'teacher', 'admin'])
 export type UserRole = z.infer<typeof UserRoleSchema>;
 
 export const UserSchema = z.object({


### PR DESCRIPTION
## Summary
- extend user roles with new `admin` option
- add `AdminGuard` and `TeacherGuard` to protect admin and teacher routes
- secure sign-up endpoint so only authenticated admins can create users
- add `mock-admin-sign-in` endpoint that returns an admin JWT only for localhost requests
- export `JwtModule` from the auth module to support the mock sign-in endpoint

## Testing
- `npm test` (fails: Missing script: "test")
- `npx nx test api-server`


------
https://chatgpt.com/codex/tasks/task_e_6898b0d69aa88324946ec3cabe616751