### PR TITLE
feat(database): add user table migration

### DIFF
--- a/backend/packages/dev/database/schema/metadata/databases/main_db/tables/tables.yaml
+++ b/backend/packages/dev/database/schema/metadata/databases/main_db/tables/tables.yaml
@@ -2,3 +2,4 @@
 - "!include saito_tasks.yaml"
 - "!include knowledge_points.yaml"
 - "!include quizzes.yaml"
+- "!include users.yaml"

--- a/backend/packages/dev/database/schema/metadata/databases/main_db/tables/users.yaml
+++ b/backend/packages/dev/database/schema/metadata/databases/main_db/tables/users.yaml
@@ -1,0 +1,3 @@
+table:
+  name: users
+  schema: kedge_gateway

--- a/backend/packages/dev/database/schema/migrations/main_db/1741604053_create_users_table/up.sql
+++ b/backend/packages/dev/database/schema/migrations/main_db/1741604053_create_users_table/up.sql
@@ -1,7 +1,7 @@
 -- Enable UUID generation extension
 CREATE EXTENSION IF NOT EXISTS pgcrypto;
 
--- Create the schema
+-- Create the schema if it does not exist
 CREATE SCHEMA IF NOT EXISTS kedge_gateway;
 
 -- Trigger function to update the updated_at column
@@ -18,9 +18,8 @@ END;
 $$
 LANGUAGE plpgsql;
 
-
 -- Users table
-CREATE TABLE kedge_gateway.users (
+CREATE TABLE IF NOT EXISTS kedge_gateway.users (
                                    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
                                    name VARCHAR(255) NOT NULL UNIQUE,
                                    password_hash TEXT NOT NULL,


### PR DESCRIPTION
## Summary
- add migration to create `kedge_gateway.users`
- track users table in Hasura metadata

## Testing
- `pnpm nx run-many --target=test --all`
- `pnpm nx format:check --files packages/dev/database/schema/migrations/main_db/1741604053_create_users_table/up.sql packages/dev/database/schema/migrations/main_db/1741604053_create_users_table/down.sql packages/dev/database/schema/metadata/databases/main_db/tables/users.yaml packages/dev/database/schema/metadata/databases/main_db/tables/tables.yaml`

------
https://chatgpt.com/codex/tasks/task_e_6898b9387778832484b5814a787b2cbb