### PR TITLE
docs: document backend env vars

### DIFF
--- a/backend/.envrc
+++ b/backend/.envrc
@@ -28,6 +28,13 @@ export REDIS_HOST=localhost
 export REDIS_PORT=6379
 
 export API_PORT=8718
+export ENABLE_DEBUG_INFO=true
+export LOG_LEVEL=debug
+export NODE_ENV=development
+export QUIZ_STORAGE_PATH="./quiz-storage"
+
+# OpenAI API key for GPT-based modules
+# export OPENAI_API_KEY=""
 
 if [[ -f .envrc.override ]]; then
   source_env .envrc.override


### PR DESCRIPTION
## Summary
- document OpenAI API key placeholder for GPT modules
- add placeholders for backend runtime env vars in `.envrc`

## Testing
- `pnpm run test` (fails: Missing script: test)


------
https://chatgpt.com/codex/tasks/task_e_68994c7bddb483248c2b9a85d2d3fd17